### PR TITLE
Ansible playbooks to migrate OONI data-pipeline

### DIFF
--- a/ansible/server_migration/README
+++ b/ansible/server_migration/README
@@ -1,0 +1,7 @@
+This ansible recipe aims to automate the process of migrating OONI
+data-pipeline to a new server.
+
+It should be run with:
+ansible-playbook -i hosts main.yml -vvvv
+
+hosts file contains the user/server/variables configuration

--- a/ansible/server_migration/apt_debian-testing.preferences
+++ b/ansible/server_migration/apt_debian-testing.preferences
@@ -1,0 +1,7 @@
+Package: *
+Pin: release a=stable
+Pin-Priority: 700
+
+Package: *
+Pin: release a=testing
+Pin-Priority: 90

--- a/ansible/server_migration/deploy-containers.yml
+++ b/ansible/server_migration/deploy-containers.yml
@@ -1,0 +1,86 @@
+---
+- hosts: ooni-pipeline-hosts
+  sudo: yes
+  vars:
+    - dockers_path: '{{ OONI_SYSADMIN_PATH }}/docker'
+  tasks:
+  - name: Install ansible requirements for docker
+    apt: name={{ item }} update_cache=yes state=latest default_release=testing
+    with_items:
+      - python-docker
+  - name: Checkout oonisysadmin repo
+    git: repo=https://github.com/TheTorProject/ooni-sysadmin.git 
+         dest={{ OONI_SYSADMIN_PATH }}
+  - name: Build (or check) docker images
+    docker_image: path={{ item.path }} state=build name={{ item.name }} 
+    with_items:
+      - { path: '{{ dockers_path }}/backend',
+          name: 'bridge-reachability-collector'}
+      - { path: '{{ dockers_path }}/probe',
+          name: 'bridge-reachability-probe'}
+      - { path: '{{ dockers_path }}/data-pipeline/importer',
+          name: 'ooni/import'}
+      - { path: '{{ dockers_path }}/data-pipeline/raw-data',
+          name: 'ooni/rsync-collector-raw'}
+      - { path: '{{ dockers_path }}/data-pipeline/sanitizer',
+          name: 'ooni/sanitizer'}
+      - { path: '{{ dockers_path }}/data-pipeline/web-server',
+          name: 'ooni/web-server'}
+    ignore_errors: True
+    register: docker_images
+    tags:
+       - docker_build
+  - name: Create missing directories
+    file: dest={{ item }} state=directory
+    with_items:
+      - /data/raw/
+      - /data/collector-raw-data
+      - '{{ OONI_RAW_DIR }}'
+      - '{{ OONI_SANITISED_DIR }}'
+      - '{{ OONI_ARCHIVE_DIR }}'
+      - '{{ OONI_PUBLIC_DIR }}'
+  - name: Run docker containers
+    docker: state=running image={{ item.image }} name={{ item.name }}
+            volumes={{ item.volumes }} env="{{ item.env }}"
+    with_items:
+      - { image: 'ooni/import',
+          name: 'importer',
+          env: "OONI_BRIDGE_DB_FILE={{ OONI_BRIDGE_DB_FILE }},\
+                OONI_RAW_DIR={{ OONI_RAW_DIR }},\
+                OONI_SANITISED_DIR={{ OONI_SANITISED_DIR }},\
+                OONI_ARCHIVE_DIR={{ OONI_ARCHIVE_DIR }},\
+                OONI_PUBLIC_DIR={{ OONI_PUBLIC_DIR }}",
+          volumes: "{{ OONI_SANITISED_DIR }}:{{ OONI_SANITISED_DIR }},\
+                   {{ OONI_PUBLIC_DIR }}:{{ OONI_PUBLIC_DIR }}" }
+
+      - { image: 'ooni/sanitizer',
+          name: 'ooni_sanitizer',
+          env: "OONI_BRIDGE_DB_FILE={{ OONI_BRIDGE_DB_FILE }},\
+                OONI_RAW_DIR={{ OONI_RAW_DIR }},\
+                OONI_SANITISED_DIR={{ OONI_SANITISED_DIR }},\
+                OONI_ARCHIVE_DIR={{ OONI_ARCHIVE_DIR }},\
+                OONI_PUBLIC_DIR={{ OONI_PUBLIC_DIR }},\
+                OONI_DB_IP={{ OONI_DB_IP }},\
+                OONI_DB_PORT={{ OONI_DB_PORT }},\
+                OONI_REMOTE_SERVERS_FILE = {{ OONI_REMOTE_SERVERS_FILE }}",
+          volumes: "{{ OONI_SANITISED_DIR }}:{{ OONI_SANITISED_DIR }},\
+                    {{ OONI_ARCHIVE_DIR }}:{{ OONI_ARCHIVE_DIR }},\
+                    {{ OONI_RAW_DIR }}:{{ OONI_RAW_DIR }}" }
+  - name: Run docker containers
+    docker: state=running image={{ item.image }} name={{ item.name }}
+            volumes={{ item.volumes }}
+    with_items:
+      - { image: 'ooni/rsync-collector-raw',
+          name: 'rsync-collector-raw',
+          volumes: "/data/raw/:/data/raw,\
+                   /data/collector-raw-data:/data/collector-raw-data" }
+      - { image: 'ooni/collector',
+          name: 'bridge-reachability-collector',
+          volumes: "/data/collector/:/data"}
+      - { image: 'ooni/probe-bridge-reachability',
+          name: 'bridge-reachability-probe',
+          volumes: "/data/probe/bridge_reachability/:/data/bridge_reachability/"}
+    ignore_errors: True
+  - name: Run remaining docker containers
+    docker: state=running image='ooni/web-server' name='web-server'
+            volumes='{{ OONI_PUBLIC_DIR }}:/srv/www/' ports='80:80'

--- a/ansible/server_migration/hosts
+++ b/ansible/server_migration/hosts
@@ -1,0 +1,16 @@
+[ooni-pipeline-hosts]
+local
+
+[ooni-pipeline-hosts:vars]
+#ansible_ssh_user=
+#ansible_ssh_private_key_file=
+
+OONI_BRIDGE_DB_FILE=/data/pipeline/raw/path_to_ip_port_based_mapping.json
+OONI_RAW_DIR=/data/pipeline/raw/
+OONI_SANITISED_DIR=/data/pipeline/sanitised/
+OONI_ARCHIVE_DIR=/data/pipeline/sanitized-archive/
+OONI_PUBLIC_DIR=/data/pipeline/public/
+OONI_DB_IP=127.0.0.1
+OONI_DB_PORT=27017
+OONI_REMOTE_SERVERS_FILE=/data/pipeline/remote_servers.txt
+OONI_SYSADMIN_PATH=/tmp/ooni-sysadmin

--- a/ansible/server_migration/install-docker.yml
+++ b/ansible/server_migration/install-docker.yml
@@ -1,0 +1,20 @@
+---
+- hosts: ooni-pipeline-hosts
+  sudo: yes
+  tasks:
+  - name: Install ansible requirements for apt module
+    apt: name={{item}} update_cache=yes state=latest
+    with_items:
+    - python-apt
+    - apt-transport-https
+  - name: Add Debian testing repo
+    apt_repository: repo='deb http://cdn.debian.net/debian/ testing main' 
+                    state=present update_cache=yes
+  - name: Configure APT preferences for Debian stable/testing
+    template: src=apt_debian-testing.preferences 
+              dest=/etc/apt/preferences.d/apt_debian-testing.pref
+              owner=root group=root mode=0644 backup=yes
+  - name: Apt install docker.io
+    apt: name={{ item }} update_cache=yes default_release=testing
+    with_items:
+    - docker.io

--- a/ansible/server_migration/main.yml
+++ b/ansible/server_migration/main.yml
@@ -1,0 +1,3 @@
+---
+- include: install-docker.yml
+- include: deploy-containers.yml


### PR DESCRIPTION
Includes the playbooks needed to migrate OONI data-pipeline containers and
configuration to a remote server.
Reference: trac-13825
