### PR TITLE
Add deployment playbook for various test-helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ invoke.yaml
 *.swo
 backend-files/
 secrets.env.j2
+*.secrets

--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ golang-go package.
 ansible-playbook -i "hosts-inventory" ansible/install-ooniprobe.yml -v
 ```
 
+## ooni-backend
+
+This ansible role deploys ooni-backend dns, tcp_echo and
+http_return_json_headers test-helpers.
+
+### execute role
+
+```
+ansible-playbook -i ansible/inventory ansible/install-oonibackend.yml
+```
+
 ## Third party tools
 
 This ansible role install third party tools required for some ooniprobe

--- a/ansible/deploy-oonibackend-test-helpers.yml
+++ b/ansible/deploy-oonibackend-test-helpers.yml
@@ -1,0 +1,11 @@
+---
+- hosts: test-helpers
+  vars:
+    docker_deployment: yes
+    docker_ip: 0.0.0.0
+    test_helper: yes
+    bind_oonibackend_data_path: "/data/{{ ansible_nodename }}"
+    docker_img_name: "ooni-backend-{{ ansible_nodename }}"
+  roles:
+    - docker_py
+    - ooni-backend

--- a/ansible/deploy-oonibackend-test-helpers.yml
+++ b/ansible/deploy-oonibackend-test-helpers.yml
@@ -2,7 +2,6 @@
 - hosts: test-helpers
   vars:
     docker_deployment: yes
-    docker_ip: 0.0.0.0
     test_helper: yes
     bind_oonibackend_data_path: "/data/{{ ansible_nodename }}"
     docker_img_name: "ooni-backend-{{ ansible_nodename }}"

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -89,3 +89,23 @@ separate.bouncer.test.ooni.io # DELETE
 separate.a.web-connectivity.th.test.ooni.io # DELETE
 seedling.infra.ooni.io # DELETE
 reports.ooni.nu # vps770.greenhost.nl NOT-GH - DELETE
+
+[test-helpers:children] # oonibackend test-helpers group
+http-test-helpers
+echo-test-helpers
+
+[http-test-helpers] # oonibackend http test-helper group
+a.http.th.ooni.io http_return_json_headers_address=37.218.247.95 dns_test_helper_address=37.218.247.95:57004
+
+[http-test-helpers:vars]
+enable_tcp_echo_helper=no
+enable_daphn3_helper=no
+http_return_json_headers_port=80
+
+[echo-test-helpers] # oonibackend echo test-helper group
+a.echo.th.ooni.io tcp_echo_address=199.119.112.49 dns_test_helper_address=199.119.112.49:57004
+c.echo.th.ooni.io tcp_echo_address=37.218.247.110 dns_test_helper_address=37.218.247.110:57004
+
+[echo-test-helpers:vars]
+enable_http_return_json_headers_helper=no
+tcp_echo_port=80

--- a/ansible/roles/docker_py/tasks/main.yml
+++ b/ansible/roles/docker_py/tasks/main.yml
@@ -4,9 +4,11 @@
   apt: >
     name={{ item }}
     state=present
+    update_cache=yes
   with_items:
     - apt-transport-https
     - python-virtualenv
+    - python-pip
 
 - name: adds Docker repository key
   apt_key: >

--- a/ansible/roles/ooni-backend/defaults/main.yml
+++ b/ansible/roles/ooni-backend/defaults/main.yml
@@ -1,0 +1,21 @@
+enable_dns_helper: yes
+enable_dns_discovery_helper: yes
+enable_http_return_json_headers_helper: yes
+enable_tcp_echo_helper: yes
+enable_daphn3_helper: yes
+
+dns_resolver_address: "8.8.8.8:53"
+dns_test_helper_address: "213.138.109.232:57004"
+http_return_json_headers_address: "http://93.95.227.200"
+ssl_address:
+tcp_echo_address: "213.138.109.232"
+traceroute_address: "213.138.109.232"
+http_return_json_headers_port: 57001
+tcp_echo_port: 57002
+daphn3_port: 57003
+dns_port_tcp: 57004
+dns_port_udp: 57004
+dns_discover_port_tcp: 57005
+dns_discover_port_udp: 57005
+ssl_port: 57006
+docker_ip: 0.0.0.0

--- a/ansible/roles/ooni-backend/defaults/main.yml
+++ b/ansible/roles/ooni-backend/defaults/main.yml
@@ -5,11 +5,11 @@ enable_tcp_echo_helper: yes
 enable_daphn3_helper: yes
 
 dns_resolver_address: "8.8.8.8:53"
-dns_test_helper_address: "213.138.109.232:57004"
-http_return_json_headers_address: "http://93.95.227.200"
+dns_test_helper_address: "37.218.247.110:57004"
+http_return_json_headers_address: "http://37.218.247.95"
 ssl_address:
-tcp_echo_address: "213.138.109.232"
-traceroute_address: "213.138.109.232"
+tcp_echo_address: "37.218.247.110"
+traceroute_address: "199.119.112.49"
 http_return_json_headers_port: 57001
 tcp_echo_port: 57002
 daphn3_port: 57003

--- a/ansible/roles/ooni-backend/defaults/main.yml
+++ b/ansible/roles/ooni-backend/defaults/main.yml
@@ -1,5 +1,4 @@
 enable_dns_helper: yes
-enable_dns_discovery_helper: yes
 enable_http_return_json_headers_helper: yes
 enable_tcp_echo_helper: yes
 enable_daphn3_helper: yes
@@ -14,8 +13,6 @@ http_return_json_headers_port: 57001
 tcp_echo_port: 57002
 daphn3_port: 57003
 dns_port_tcp: 57004
-dns_port_udp: 57004
-dns_discover_port_tcp: 57005
-dns_discover_port_udp: 57005
+dns_port_udp: 57005
 ssl_port: 57006
 docker_ip: 0.0.0.0

--- a/ansible/roles/ooni-backend/defaults/main.yml
+++ b/ansible/roles/ooni-backend/defaults/main.yml
@@ -12,7 +12,7 @@ traceroute_address: "199.119.112.49"
 http_return_json_headers_port: 57001
 tcp_echo_port: 57002
 daphn3_port: 57003
-dns_port_tcp: 57004
-dns_port_udp: 57005
+dns_port_tcp: 57005
+dns_port_udp: 57004
 ssl_port: 57006
 docker_ip: 0.0.0.0

--- a/ansible/roles/ooni-backend/hosts
+++ b/ansible/roles/ooni-backend/hosts
@@ -15,3 +15,8 @@ docker_ip="0.0.0.0"
 # The list of generated domain could be derived from groups_vars/group
 # Set to true to install ooni-backend from git repository. Default: PyPI install
 # oonibackend_git_install=true
+# dns_resolver_address="8.8.8.8:53"
+# dns_test_helper_address="213.138.109.232:57004"
+# http_return_json_headers_address="http://93.95.227.200"
+# tcp_echo_address="213.138.109.232"
+# traceroute_address="213.138.109.232"

--- a/ansible/roles/ooni-backend/tasks/docker_instances.yml
+++ b/ansible/roles/ooni-backend/tasks/docker_instances.yml
@@ -87,3 +87,29 @@
     - "{{ bind_oonibackend_data_path }}:{{ oonibackend_data_path }}"
     restart_policy: always
   when: enable_web_connectivity is defined
+
+- name: runs oonibackend test helpers docker image
+  docker_container:
+    state: started
+    name: "{{ docker_img_name }}"
+    image: "{{ docker_img_name }}"
+    expose:
+    - "{{ http_return_json_headers_port }}"
+    - "{{ tcp_echo_port }}"
+    - "{{ daphn3_port }}"
+    - "{{ dns_port_tcp }}"
+    - "{{ dns_discover_port_tcp }}"
+    ports:
+    - "{{ docker_ip }}:{{ http_return_json_headers_port }}:{{ http_return_json_headers_port }}"
+    - "{{ docker_ip }}:{{ tcp_echo_port }}:{{ tcp_echo_port }}"
+    - "{{ docker_ip }}:{{ daphn3_port }}:{{ daphn3_port }}"
+    - "{{ docker_ip }}:{{ dns_port_tcp }}:{{ dns_port_tcp }}"
+    - "{{ docker_ip }}:{{ dns_discover_port_tcp }}:{{ dns_discover_port_tcp }}"
+    volumes:
+    - "{{ bind_deck_dir }}:{{ deck_dir }}"
+    - "{{ bind_input_dir }}:{{ input_dir }}"
+    - "{{ bind_oonibackend_log_path }}:{{ oonibackend_log_path }}"
+    - "{{ bind_oonibackend_conf_path }}:{{ oonibackend_conf_path }}"
+    - "{{ bind_oonibackend_data_path }}:{{ oonibackend_data_path }}"
+    restart_policy: always
+  when: test_helper is defined

--- a/ansible/roles/ooni-backend/tasks/docker_instances.yml
+++ b/ansible/roles/ooni-backend/tasks/docker_instances.yml
@@ -98,17 +98,13 @@
     - "{{ tcp_echo_port }}"
     - "{{ daphn3_port }}"
     - "{{ dns_port_tcp }}"
-    - "{{ dns_discover_port_tcp }}"
     - "{{ dns_port_udp }}"
-    - "{{ dns_discover_port_udp }}"
     ports:
     - "{{ docker_ip }}:{{ http_return_json_headers_port }}:{{ http_return_json_headers_port }}"
     - "{{ docker_ip }}:{{ tcp_echo_port }}:{{ tcp_echo_port }}"
     - "{{ docker_ip }}:{{ daphn3_port }}:{{ daphn3_port }}"
     - "{{ docker_ip }}:{{ dns_port_tcp }}:{{ dns_port_tcp }}"
-    - "{{ docker_ip }}:{{ dns_discover_port_tcp }}:{{ dns_discover_port_tcp }}"
     - "{{ docker_ip }}:{{ dns_port_udp }}:{{ dns_port_udp }}/udp"
-    - "{{ docker_ip }}:{{ dns_discover_port_udp }}:{{ dns_discover_port_udp }}/udp"
     volumes:
     - "{{ bind_deck_dir }}:{{ deck_dir }}"
     - "{{ bind_input_dir }}:{{ input_dir }}"

--- a/ansible/roles/ooni-backend/tasks/docker_instances.yml
+++ b/ansible/roles/ooni-backend/tasks/docker_instances.yml
@@ -99,12 +99,16 @@
     - "{{ daphn3_port }}"
     - "{{ dns_port_tcp }}"
     - "{{ dns_discover_port_tcp }}"
+    - "{{ dns_port_udp }}"
+    - "{{ dns_discover_port_udp }}"
     ports:
     - "{{ docker_ip }}:{{ http_return_json_headers_port }}:{{ http_return_json_headers_port }}"
     - "{{ docker_ip }}:{{ tcp_echo_port }}:{{ tcp_echo_port }}"
     - "{{ docker_ip }}:{{ daphn3_port }}:{{ daphn3_port }}"
     - "{{ docker_ip }}:{{ dns_port_tcp }}:{{ dns_port_tcp }}"
     - "{{ docker_ip }}:{{ dns_discover_port_tcp }}:{{ dns_discover_port_tcp }}"
+    - "{{ docker_ip }}:{{ dns_port_udp }}:{{ dns_port_udp }}/udp"
+    - "{{ docker_ip }}:{{ dns_discover_port_udp }}:{{ dns_discover_port_udp }}/udp"
     volumes:
     - "{{ bind_deck_dir }}:{{ deck_dir }}"
     - "{{ bind_input_dir }}:{{ input_dir }}"

--- a/ansible/roles/ooni-backend/tasks/main.yml
+++ b/ansible/roles/ooni-backend/tasks/main.yml
@@ -10,6 +10,6 @@
 - include: docker_instances.yml
   when: docker_deployment is defined
 - include: populate_bouncer_base.yml
-  when: docker_deployment is defined
+  when: docker_deployment is defined and test_helper is not defined
 - include: cron.yml
-  when: docker_deployment is defined
+  when: docker_deployment is defined and test_helper is not defined

--- a/ansible/roles/ooni-backend/templates/Dockerfile.j2
+++ b/ansible/roles/ooni-backend/templates/Dockerfile.j2
@@ -6,8 +6,8 @@ RUN echo "deb http://deb.torproject.org/torproject.org jessie main" \
 RUN apt-get -y update
 RUN apt-get install -y git-core python-pip python-dev libsqlite3-dev \
                        libffi-dev tor deb.torproject.org-keyring
-{% if ( oonibackend_git_install|default('false')|bool ) %}
-RUN pip install git+{{ ooni_backend_repo }}
+{% if ( oonibackend_git_install|default('true')|bool ) %}
+RUN pip install git+{{ ooni_backend_repo }}@{{ooni_backend_git_hash }}
 {% else %}
 RUN pip install oonibackend
 {% endif %}

--- a/ansible/roles/ooni-backend/templates/oonibackend.conf.j2
+++ b/ansible/roles/ooni-backend/templates/oonibackend.conf.j2
@@ -21,7 +21,7 @@ helpers:
   dns_discovery:
     address: null
     resolver_address: null
-{% if enable_dns_discovery_helper %}
+{% if enable_dns_discovery_helper | default('') %}
     tcp_port: {{ dns_discover_port_tcp }}
     udp_port: {{ dns_discover_port_udp }}
 {% else %}

--- a/ansible/roles/ooni-backend/vars/main.yml
+++ b/ansible/roles/ooni-backend/vars/main.yml
@@ -1,31 +1,11 @@
 oonibackend_package: oonibackend
-enable_dns_helper: yes
-enable_dns_discovery_helper: yes
-enable_http_return_json_headers_helper: yes
-enable_tcp_echo_helper: yes
-enable_daphn3_helper: yes
 
-dns_resolver_address: "8.8.8.8:53"
-dns_test_helper_address: "213.138.109.232:57004"
-http_return_json_headers_address: "http://93.95.227.200"
-ssl_address:
-tcp_echo_address: "213.138.109.232"
-traceroute_address: "213.138.109.232"
 web_connectivity_domain: "{{ letsencrypt_domain_list|selectattr('role', 'equalto', 'web-connectivity')|map(attribute='domain')|list|join(' ') }}"
 collector_domain: "{{ letsencrypt_domain_list|selectattr('role', 'equalto', 'collector')|map(attribute='domain')|list|join(' ') }}"
 backend_conf_path: "backend-files/{{ ansible_hostname }}_{{ app_env }}"
 web_connectivity_hs: "{{lookup('file', '{{ backend_conf_path }}/web_connectivity/hostname')}}"
 collector_hs: "{{lookup('file', '{{ backend_conf_path }}/collector/hostname')}}"
 bouncer_hs: "{{lookup('file', '{{ backend_conf_path }}/bouncer/hostname')}}"
-
-http_return_json_headers_port: 57001
-tcp_echo_port: 57002
-daphn3_port: 57003
-dns_port_tcp: 57004
-dns_port_udp: 57004
-dns_discover_port_tcp: 57005
-dns_discover_port_udp: 57005
-ssl_port: 57006
 
 oonibackend_data_path: /usr/share/ooni/backend
 archive_dir: "{{ oonibackend_data_path }}/archive"

--- a/ansible/roles/ooni-backend/vars/main.yml
+++ b/ansible/roles/ooni-backend/vars/main.yml
@@ -52,4 +52,4 @@ bind_oonibackend_log_path: "{{ bind_oonibackend_data_path }}/var/log/ooni"
 bind_oonibackend_conf: "{{ bind_oonibackend_conf_path }}/oonibackend.conf"
 ooni_sysadmin_repo: "https://github.com/TheTorProject/ooni-sysadmin.git"
 ooni_backend_repo: "https://github.com/TheTorProject/ooni-backend.git"
-ooni_backend_git_hash: 5395ce8275c87526b443cfc63c4db37e4b1f3ce8
+ooni_backend_git_hash: v1.3.3

--- a/ansible/roles/ooni-backend/vars/main.yml
+++ b/ansible/roles/ooni-backend/vars/main.yml
@@ -72,3 +72,4 @@ bind_oonibackend_log_path: "{{ bind_oonibackend_data_path }}/var/log/ooni"
 bind_oonibackend_conf: "{{ bind_oonibackend_conf_path }}/oonibackend.conf"
 ooni_sysadmin_repo: "https://github.com/TheTorProject/ooni-sysadmin.git"
 ooni_backend_repo: "https://github.com/TheTorProject/ooni-backend.git"
+ooni_backend_git_hash: 5395ce8275c87526b443cfc63c4db37e4b1f3ce8


### PR DESCRIPTION
* Adds a deployment playbook for dns, tcp_echo, http_return_json_headers
  test helpers
* Update .gitignore
* Set a specific git commit hash for deployment
* Create test-helpers specific docker image