### PR TITLE
QnD update of deploy-ooni-orchestrate.yml to work with updated `letsencrypt` role

### DIFF
--- a/ansible/deploy-ooni-orchestrate.yml
+++ b/ansible/deploy-ooni-orchestrate.yml
@@ -1,27 +1,28 @@
 - hosts: events.proteus.test.ooni.io
   vars:
     orchestra_orchestrate_https_port: 443
-    letsencrypt_nginx: yes
-    letsencrypt_domains: "{{ inventory_hostname }}"
     orchestra_database_url: "{{ orchestra_database_url_testing }}"
     orchestra_auth_jwt_secret : "{{ orchestra_auth_jwt_secret_testing }}"
     orchestra_notify_url: "https://notify.proteus.test.ooni.io"
     orchestra_notify_basic_auth_password: "{{ orchestra_notify_basic_auth_password_testing }}"
     orchestra_notify_topic_ios: "org.openobservatory.NetProbe"
   roles:
-    - letsencrypt
+    - role: letsencrypt
+      tags: letsencrypt
+      letsencrypt_domains: "{{ inventory_hostname }}" # BTW, that's strong anti-pattern
     - ooni-orchestrate
 
 - hosts: events.proteus.ooni.io
   vars:
     orchestra_orchestrate_https_port: 443
-    letsencrypt_nginx: yes
-    letsencrypt_domains: "events.proteus.ooni.io"
     # orchestra_database_url: "{{ orchestra_database_url }}"
     # orchestra_auth_jwt_secret : "{{ orchestra_auth_jwt_secret }}"
     orchestra_notify_url: "https://notify.proteus.ooni.io"
     # orchestra_notify_basic_auth_password: "{{ orchestra_notify_basic_auth_password }}"
     orchestra_notify_topic_ios: "org.openobservatory.ooniprobe"
   roles:
-    - letsencrypt
+    - role: letsencrypt
+      tags: letsencrypt
+      # orchestrate.* is "canonical" name, events.proteus.* is "legacy" from MK that was never released as OONI Probe (and may be eventually dropped)
+      letsencrypt_domains: ["orchestrate.ooni.io", "events.proteus.ooni.io"]
     - ooni-orchestrate


### PR DESCRIPTION
QnD stands for Quick-and-Dirty.

I've recently updated `letsencrypt` to make it more clean and to work together with `nginx-stable` role (e.g. `letsencrypt_nginx` was dropped).
But I've not migrated ALL the services to `nginx-stable`. And my mistake was to update `letsencrypt` role in-place instead of creation of `le_v2` as a copy and doing modifications there.
I tried to do it with branch `alert-18` but something from that branch was needed to do something else, so it was merged to `master` and it made things worse.
Anyway, I feel like "re-deploy OONI infra" will be a long story given amount of pain accumulated here.