### PR TITLE
Fix systemd alerts

### DIFF
--- a/ansible/dom0-bootstrap.yml
+++ b/ansible/dom0-bootstrap.yml
@@ -54,3 +54,9 @@
       tags: on-rename
     - role: node_exporter
       tags: node_exporter
+
+- hosts: gh
+  gather_facts: false
+  roles:
+    - role: eclipsis
+      tags: gh

--- a/ansible/dom0-bootstrap.yml
+++ b/ansible/dom0-bootstrap.yml
@@ -58,5 +58,5 @@
 - hosts: gh
   gather_facts: false
   roles:
-    - role: eclipsis
+    - role: gh
       tags: gh

--- a/ansible/dom0-bootstrap.yml
+++ b/ansible/dom0-bootstrap.yml
@@ -26,6 +26,12 @@
     - role: ntp
       tags: ntp
 
+- hosts: gh
+  gather_facts: false
+  roles:
+    - role: gh
+      tags: gh
+
 - hosts: have_fw
   gather_facts: false
   roles:
@@ -55,8 +61,3 @@
     - role: node_exporter
       tags: node_exporter
 
-- hosts: gh
-  gather_facts: false
-  roles:
-    - role: gh
-      tags: gh

--- a/ansible/roles/eclipsis/tasks/main.yml
+++ b/ansible/roles/eclipsis/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# This role is part of the bootstrap process and does changes specific to the
+# eclipsis platform
+
+- name: Disable the apparmor service, since the kernel doesn't support it
+  systemd:
+    enabled: no
+    name: apparmor

--- a/ansible/roles/eclipsis/tasks/main.yml
+++ b/ansible/roles/eclipsis/tasks/main.yml
@@ -1,8 +1,0 @@
----
-# This role is part of the bootstrap process and does changes specific to the
-# eclipsis platform
-
-- name: Disable the apparmor service, since the kernel doesn't support it
-  systemd:
-    enabled: no
-    name: apparmor

--- a/ansible/roles/gh/tasks/main.yml
+++ b/ansible/roles/gh/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+# This role is part of the bootstrap process and does changes specific to the
+# eclipsis platform
+
+#- name: Disable the apparmor service, since the kernel doesn't support it
+#  systemd:
+#    enabled: no
+#    name: apparmor
+
+- name: Check if smartd exists
+  stat: path=/etc/init.d/smartmontools
+  register: smartd_init
+
+- name: Disable the smartd as we are in a virtualized environment
+  systemd:
+    daemon_reload: yes
+    enabled: no
+    state: stopped
+    name: smartd
+  when: smartd_init.stat.exists
+  register: systemd_reload_failed
+
+# XXX it's unclear what would be the best way to do this conditionally on if it
+# having just been removed.
+# This currently has the side-effect of resetting the failed state of all
+# systemd units.
+- name: Reset the failed state of systemd
+  command: systemctl reset-failed
+  when: systemd_reload_failed


### PR DESCRIPTION
I believe now the only one that is still broken is `bouncer.infra.ooni.nu`, yet this is a box we should phase out/deprecate anyways and `labs.ooni.io` where the certbot script is not working as expected (it's a testing machine so it's not essential).

* apparmor was actually only a problem on wiki.ooni.io, which I just disabled
* There was a certbot problem on hkgbouncer, which was due to some empty config file being left over from some bad upgrade or something (I just deleted it)
* datacollector had a broken ntp service, which I fixed by running updating the ntp client

The remaining alerts were just related to smartd being broken, which is now disabled as part of the playbook on all greenhost boxes.