### PR TITLE
Serve static files as placeholder API data for explorer country pages

### DIFF
--- a/ansible/roles/ooni-explorer-next/defaults/main.yml
+++ b/ansible/roles/ooni-explorer-next/defaults/main.yml
@@ -1,3 +1,4 @@
 explorer_next_tag: '20181112-00674a72'
 explorer_next_backend_ipv4: 172.27.33.254
 explorer_next_backend_port: 3100
+explorer_country_data_path: /var/www/explorer

--- a/ansible/roles/ooni-explorer-next/defaults/main.yml
+++ b/ansible/roles/ooni-explorer-next/defaults/main.yml
@@ -1,4 +1,4 @@
-explorer_next_tag: '20181112-00674a72'
+explorer_next_tag: '20181212-b55c9c80'
 explorer_next_backend_ipv4: 172.27.33.254
 explorer_next_backend_port: 3100
 explorer_country_data_path: /var/www/explorer

--- a/ansible/roles/ooni-explorer-next/tasks/main.yml
+++ b/ansible/roles/ooni-explorer-next/tasks/main.yml
@@ -22,4 +22,12 @@
       NODE_ENV: production
     user: "{{ passwd.explorer.id }}:{{ passwd.explorer.id }}"
     restart_policy: unless-stopped
+
+- name: Directory to serve data from
+  file:
+    path: "{{ explorer_country_data_path }}"
+    state: directory
+    owner: "{{ passwd.explorer.id }}"
+    group: "{{ passwd.explorer.id }}"
+    mode: "u=rxw,g=rx,o="
 ...

--- a/ansible/roles/ooni-explorer-next/templates/ngx-explorer
+++ b/ansible/roles/ooni-explorer-next/templates/ngx-explorer
@@ -26,8 +26,9 @@ server {
     access_log  /var/log/nginx/{{ explorer_domain }}.access.log; # FIXME: log_format
     error_log   /var/log/nginx/{{ explorer_domain }}.error.log;
 
+    # XXX: Temporary development setup to be replaced by api.ooni.io
     location /data/ {
-        root {{ explorer_country_data_path }};
+        root {{ explorer_country_data_path }}/;
     }
 
     location / {

--- a/ansible/roles/ooni-explorer-next/templates/ngx-explorer
+++ b/ansible/roles/ooni-explorer-next/templates/ngx-explorer
@@ -26,6 +26,10 @@ server {
     access_log  /var/log/nginx/{{ explorer_domain }}.access.log; # FIXME: log_format
     error_log   /var/log/nginx/{{ explorer_domain }}.error.log;
 
+    location /data/ {
+        root {{ explorer_country_data_path }};
+    }
+
     location / {
         proxy_pass http://{{ explorer_next_backend_ipv4 }}:{{ explorer_next_backend_port }};
         include proxy_params;


### PR DESCRIPTION
Modified `explorer-next`'s nginx configuration to mock API data from static files stored in `/var/www/explorer/data/`.