### PR TITLE
Use test API server for Explorer test instance

### DIFF
--- a/ansible/deploy-ooni-explorer-next.yml
+++ b/ansible/deploy-ooni-explorer-next.yml
@@ -5,7 +5,7 @@
   roles:
     - role: docker_py
     - role: letsencrypt
-      letsencrypt_domains: ['explorer-next.ooni.io']
+      letsencrypt_domains: ['explorer-beta.ooni.io']
 
 - hosts: ooni-explorer-next.test.ooni.io
   gather_facts: false # already gathered

--- a/ansible/deploy-ooni-explorer-next.yml
+++ b/ansible/deploy-ooni-explorer-next.yml
@@ -12,7 +12,6 @@
   vars:
     ansible_python_interpreter: '/root/venv/bin/python2.7' # to control docker
     explorer_domain: explorer-beta.ooni.io
-    explorer_next_tag: '20190326-20de7f61'
   roles:
     - role: ooni-explorer-next
       tags: explorer

--- a/ansible/deploy-ooni-explorer-next.yml
+++ b/ansible/deploy-ooni-explorer-next.yml
@@ -12,6 +12,7 @@
   vars:
     ansible_python_interpreter: '/root/venv/bin/python2.7' # to control docker
     explorer_domain: ooni-explorer-next.test.ooni.io
+    explorer_next_tag: '20190319-d612ebf4'
   roles:
     - role: ooni-explorer-next
       tags: explorer

--- a/ansible/deploy-ooni-explorer-next.yml
+++ b/ansible/deploy-ooni-explorer-next.yml
@@ -5,13 +5,13 @@
   roles:
     - role: docker_py
     - role: letsencrypt
-      letsencrypt_domains: ['ooni-explorer-next.test.ooni.io']
+      letsencrypt_domains: ['explorer-next.ooni.io']
 
 - hosts: ooni-explorer-next.test.ooni.io
   gather_facts: false # already gathered
   vars:
     ansible_python_interpreter: '/root/venv/bin/python2.7' # to control docker
-    explorer_domain: ooni-explorer-next.test.ooni.io
+    explorer_domain: explorer-beta.ooni.io
     explorer_next_tag: '20190319-d612ebf4'
   roles:
     - role: ooni-explorer-next

--- a/ansible/deploy-ooni-explorer-next.yml
+++ b/ansible/deploy-ooni-explorer-next.yml
@@ -12,7 +12,7 @@
   vars:
     ansible_python_interpreter: '/root/venv/bin/python2.7' # to control docker
     explorer_domain: explorer-beta.ooni.io
-    explorer_next_tag: '20190319-d612ebf4'
+    explorer_next_tag: '20190326-20de7f61'
   roles:
     - role: ooni-explorer-next
       tags: explorer

--- a/ansible/roles/letsencrypt/tasks/main.yml
+++ b/ansible/roles/letsencrypt/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: Add Debian stable backports repository
   apt_repository:
     state: present
-    repo: deb http://httpredir.debian.org/debian {{ ansible_lsb.codename }}-backports main
-  when: ansible_lsb.id == "Debian" and ansible_lsb.codename == "jessie"
+    repo: "deb http://archive.debian.org/debian {{ ansible_lsb.codename }}-backports main"
+  when: ansible_lsb.id == "Debian" and ansible_lsb.codename == "jessie-disabled"
 
 - name: Install Letsencrypt certbot
   apt:

--- a/ansible/roles/ooni-explorer-next/defaults/main.yml
+++ b/ansible/roles/ooni-explorer-next/defaults/main.yml
@@ -1,4 +1,4 @@
-explorer_next_tag: '20190323-3fd68cfd'
+explorer_next_tag: '20190327-11a19d46'
 explorer_next_backend_ipv4: 172.27.33.254
 explorer_next_backend_port: 3100
 explorer_country_data_path: /var/www/explorer

--- a/ansible/roles/ooni-explorer-next/defaults/main.yml
+++ b/ansible/roles/ooni-explorer-next/defaults/main.yml
@@ -1,4 +1,4 @@
-explorer_next_tag: '20190418-613d8959'
+explorer_next_tag: '20190419-be9c2e02'
 explorer_next_backend_ipv4: 172.27.33.254
 explorer_next_backend_port: 3100
 explorer_country_data_path: /var/www/explorer

--- a/ansible/roles/ooni-explorer-next/defaults/main.yml
+++ b/ansible/roles/ooni-explorer-next/defaults/main.yml
@@ -1,4 +1,4 @@
-explorer_next_tag: '20190502-53881f51'
+explorer_next_tag: '20190509-5c05b2cd'
 explorer_next_backend_ipv4: 172.27.33.254
 explorer_next_backend_port: 3100
 explorer_country_data_path: /var/www/explorer

--- a/ansible/roles/ooni-explorer-next/defaults/main.yml
+++ b/ansible/roles/ooni-explorer-next/defaults/main.yml
@@ -1,4 +1,4 @@
-explorer_next_tag: '20190418-eac60290'
+explorer_next_tag: '20190418-613d8959'
 explorer_next_backend_ipv4: 172.27.33.254
 explorer_next_backend_port: 3100
 explorer_country_data_path: /var/www/explorer

--- a/ansible/roles/ooni-explorer-next/defaults/main.yml
+++ b/ansible/roles/ooni-explorer-next/defaults/main.yml
@@ -1,4 +1,4 @@
-explorer_next_tag: '20190509-5c05b2cd'
+explorer_next_tag: '20190517-4b9de49f'
 explorer_next_backend_ipv4: 172.27.33.254
 explorer_next_backend_port: 3100
 explorer_country_data_path: /var/www/explorer

--- a/ansible/roles/ooni-explorer-next/defaults/main.yml
+++ b/ansible/roles/ooni-explorer-next/defaults/main.yml
@@ -1,4 +1,4 @@
-explorer_next_tag: '20190419-be9c2e02'
+explorer_next_tag: '20190502-9d7edbb4'
 explorer_next_backend_ipv4: 172.27.33.254
 explorer_next_backend_port: 3100
 explorer_country_data_path: /var/www/explorer

--- a/ansible/roles/ooni-explorer-next/defaults/main.yml
+++ b/ansible/roles/ooni-explorer-next/defaults/main.yml
@@ -1,4 +1,4 @@
-explorer_next_tag: '20190327-11a19d46'
+explorer_next_tag: '20190418-eac60290'
 explorer_next_backend_ipv4: 172.27.33.254
 explorer_next_backend_port: 3100
 explorer_country_data_path: /var/www/explorer

--- a/ansible/roles/ooni-explorer-next/defaults/main.yml
+++ b/ansible/roles/ooni-explorer-next/defaults/main.yml
@@ -1,4 +1,4 @@
-explorer_next_tag: '20190502-9d7edbb4'
+explorer_next_tag: '20190502-53881f51'
 explorer_next_backend_ipv4: 172.27.33.254
 explorer_next_backend_port: 3100
 explorer_country_data_path: /var/www/explorer

--- a/ansible/roles/ooni-explorer-next/tasks/main.yml
+++ b/ansible/roles/ooni-explorer-next/tasks/main.yml
@@ -20,7 +20,6 @@
     purge_networks: true
     env:
       NODE_ENV: production
-      MEASUREMENTS_URL: http://api.test.ooni.io
     user: "{{ passwd.explorer.id }}:{{ passwd.explorer.id }}"
     restart_policy: unless-stopped
 

--- a/ansible/roles/ooni-explorer-next/tasks/main.yml
+++ b/ansible/roles/ooni-explorer-next/tasks/main.yml
@@ -20,6 +20,7 @@
     purge_networks: true
     env:
       NODE_ENV: production
+      MEASUREMENTS_URL: http://api.test.ooni.io
     user: "{{ passwd.explorer.id }}:{{ passwd.explorer.id }}"
     restart_policy: unless-stopped
 


### PR DESCRIPTION
I tried switching the API server address provided as an environment variable. Doesn't seem to be the right way. The country page which fetches data from the new endpoints on the API server seems to still hit the production API server (based on docker logs).