### PR TITLE
Tighten up firewall for ooni/orchestra database

### DIFF
--- a/ansible/inventory
+++ b/ansible/inventory
@@ -139,8 +139,8 @@ datacollector.infra.ooni.io
 hkgmetadb.infra.ooni.io
 amsmetadb.ooni.nu
 ssdams.infra.ooni.io
-# db-1.proteus.test.ooni.io
-# db-1.proteus.ooni.io
+db-1.proteus.test.ooni.io
+db-1.proteus.ooni.io
 hkgtorth.ooni.nu
 miatorth.ooni.nu
 amstorth.ooni.nu

--- a/ansible/templates/iptables.filter.part/db-1.proteus.ooni.io
+++ b/ansible/templates/iptables.filter.part/db-1.proteus.ooni.io
@@ -1,0 +1,7 @@
+{% extends 'iptables.filter.part' %}
+{% block svc %}
+# postgresql
+-A INPUT -s {{ lookup('dig', 'registry.proteus.ooni.io/A') }}/32 -p tcp -m tcp --dport 5432 -j ACCEPT
+-A INPUT -s {{ lookup('dig', 'events.proteus.ooni.io/A') }}/32 -p tcp -m tcp --dport 5432 -j ACCEPT
+-A INPUT -s {{ lookup('dig', 'datacollector.infra.ooni.io/A') }}/32 -p tcp -m tcp --dport 5432 -j ACCEPT
+{% endblock %}

--- a/ansible/templates/iptables.filter.part/db-1.proteus.test.ooni.io
+++ b/ansible/templates/iptables.filter.part/db-1.proteus.test.ooni.io
@@ -1,0 +1,6 @@
+{% extends 'iptables.filter.part' %}
+{% block svc %}
+# postgresql
+-A INPUT -s {{ lookup('dig', 'registry.proteus.test.ooni.io/A') }}/32 -p tcp -m tcp --dport 5432 -j ACCEPT
+-A INPUT -s {{ lookup('dig', 'events.proteus.test.ooni.io/A') }}/32 -p tcp -m tcp --dport 5432 -j ACCEPT
+{% endblock %}


### PR DESCRIPTION
@hellais I assume you may want to tighten up firewall settings a bit on a DB box tracking OONI Probes.

I'm not rolling that out myself as I'm unsure if the list is still up-to-date. Seems, it is, but I may be missing something.