### PR TITLE
Add comment on built-in docker init

### DIFF
--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -19,4 +19,5 @@ COPY entrypoint.sh /entrypoint.sh
 USER airflow
 
 # One can't enforce ulimit or get OOM on PID=1
+# `dumb-init` may be replaced with `docker run --init` in modern docker versions.
 ENTRYPOINT ["/usr/bin/dumb-init", "-v", "/entrypoint.sh"]


### PR DESCRIPTION
I'm cleaning up various notes and found a note on `dumb-init`. Actually, it's no longer needed, it's possible to replace it with `tini` that is shipped with modern docker versions.

I'm leaving it as a comment instead of separate ticket as there is no _need_ to drop `dumb-init`, it's just some cleanup.