### PR TITLE
Update orchestrate to 0.3.0

### DIFF
--- a/ansible/deploy-ooni-orchestrate.yml
+++ b/ansible/deploy-ooni-orchestrate.yml
@@ -6,12 +6,14 @@
     orchestra_notify_url: "https://notify.proteus.test.ooni.io"
     orchestra_notify_basic_auth_password: "{{ orchestra_notify_basic_auth_password_testing }}"
     orchestra_notify_topic_ios: "org.openobservatory.NetProbe"
+    orchestra_version: "0.3.0"
   roles:
     - role: letsencrypt
-      tags: letsencrypt
-      letsencrypt_domains: ["{{ inventory_hostname }}"] # BTW, that's strong anti-pattern
+      tags: [letsencrypt, test]
+      letsencrypt_domains: ["events.proteus.test.ooni.io", "orchestrate.test.ooni.io"]
     - role: ooni-orchestrate
-      letsencrypt_domains: ["{{ inventory_hostname }}"]
+      tags: test
+      letsencrypt_domains: ["events.proteus.test.ooni.io", "orchestrate.test.ooni.io"]
 
 - hosts: events.proteus.ooni.io
   vars:

--- a/ansible/deploy-ooni-orchestrate.yml
+++ b/ansible/deploy-ooni-orchestrate.yml
@@ -23,6 +23,7 @@
     orchestra_notify_url: "https://notify.proteus.ooni.io"
     # orchestra_notify_basic_auth_password: "{{ orchestra_notify_basic_auth_password }}"
     orchestra_notify_topic_ios: "org.openobservatory.ooniprobe"
+    orchestra_version: "0.3.0"
   roles:
     - role: letsencrypt
       tags: letsencrypt


### PR DESCRIPTION
So far I deployed 0.3.0 only on the testing infrastructure.

I think we should roll this out on the production endpoints too as it will increase testing coverage for people that have increased the maximum timeout and it has a small extra bandwidth cost.

The maximum response size will go up to 10x the current size, but it's still well under 100KB (77KB in the case of Iran which has a very big test list). Considering the fact that the web_connectivity test will likely consume much more bandwidth just to run the checks and do the upload I think it's reasonable to roll this out on production.

We may want to in the future to also do some smarter logic to impose a limit in the app by passing the `limit=` query parameter to the request.