### PR TITLE
Fix amsexplorer

### DIFF
--- a/ansible/host_vars/prometheus.infra.ooni.io/vars.yml
+++ b/ansible/host_vars/prometheus.infra.ooni.io/vars.yml
@@ -57,10 +57,10 @@ blackbox_jobs:
     targets:
       - "http://{{ lookup('dig', 'a.http.th.ooni.io/A') }}:80"
 
-  - name: "ooni explorer countByCountry"
+  - name: "ooni explorer homepage"
     module: "http_2xx"
     targets:
-      - "https://explorer.ooni.io/api/reports/countByCountry"
+      - "https://explorer.ooni.org/"
 
   - name: "ooni API files"
     module: "http_2xx"

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -138,6 +138,7 @@ amstorth.ooni.nu
 miaapi.ooni.nu
 api.ooni.io
 pipeline.test.ooni.nu
+amsexplorer.ooni.nu
 
 [have_nginx]
 api.ooni.io

--- a/ansible/templates/iptables.filter.part/amsexplorer.ooni.nu
+++ b/ansible/templates/iptables.filter.part/amsexplorer.ooni.nu
@@ -1,0 +1,7 @@
+{% extends 'iptables.filter.part' %}
+
+{% block svc %}
+# http & https for public endpoints
+-A INPUT -p tcp -m tcp --dport 80 --tcp-flags FIN,SYN,RST,ACK SYN -j ACCEPT
+-A INPUT -p tcp -m tcp --dport 443 --tcp-flags FIN,SYN,RST,ACK SYN -j ACCEPT
+{% endblock %}


### PR DESCRIPTION
Fixes the following alerts:

> [RESOLVED] amsexplorer.ooni.nu:9100 is not `up`

This was caused by not having added the host to the `have_fw` group (new VMs on eclipsis have a much more strict firewall by default and hosts need to be added to that group in order to write a rule as part of `dom0-bootstrap` to allow prometheus to scrape it)

> [FIRING] https://explorer.ooni.io/api/reports/countByCountry endpoint down

Was caused by legacy OONI Explorer having those endpoints available. Since we deployed the new explorer those endpoints don't exists anymore and it's not a good monitoring target anymore.