### PR TITLE
currently long lines are cut off on irc

### DIFF
--- a/ansible/host_vars/mia-slack.ooni.nu/vars.yml
+++ b/ansible/host_vars/mia-slack.ooni.nu/vars.yml
@@ -33,6 +33,7 @@ slack_irc_config: |
         "retryDelay": 5000,
         "port": 6697,
         "secure": true,
+        "messageSplit": 512,
         "autoSendCommands": [
           ["PRIVMSG", "NickServ", "GHOST slacktopus {{ slacktopus_password }}" ],
           ["NICK", "slacktopus"],


### PR DESCRIPTION
Default is a message max of 512 bytes on IRC, not sure if this bot does the right thing, but according to its docs that should be it: https://node-irc.readthedocs.io/en/latest/API.html#irc.Client