### PR TITLE
Deploy orchestra serving tor config file

### DIFF
--- a/ansible/roles/probe-services/defaults/main.yml
+++ b/ansible/roles/probe-services/defaults/main.yml
@@ -19,8 +19,8 @@ orchestrate_port: 9031
 
 orchestrate_data_dir: '/srv/orchestrate'
 registry_data_dir: '/srv/registry'
-registry_docker_image: 'openobservatory/orchestra:20191217-c155ac30'
-orchestrate_docker_image: 'openobservatory/orchestra:20191217-c155ac30'
+registry_docker_image: 'openobservatory/orchestra:20200121-9d441f07'
+orchestrate_docker_image: 'openobservatory/orchestra:20200121-9d441f07'
 
 orchestra_notify_url: "https://gorush.ooni.io:8081"
 orchestra_notify_click_action_android: "org.openobservatory.ooniprobe.OPEN_BROWSER"

--- a/ansible/roles/probe-services/defaults/main.yml
+++ b/ansible/roles/probe-services/defaults/main.yml
@@ -37,3 +37,4 @@ orchestra_notify_basic_auth_password: "{{ CHANGE_ME }}"
 
 orchestra_psiphon_config_file_content: "{{ CHANGE_ME }}"
 orchestra_psiphon_config_file: "{{ orchestrate_data_dir }}/psiphon_config.json"
+orchestra_tor_targets_file: "{{ orchestrate_data_dir }}/tor_targets.json"

--- a/ansible/roles/probe-services/tasks/main.yml
+++ b/ansible/roles/probe-services/tasks/main.yml
@@ -36,6 +36,11 @@
     content: "{{ orchestra_psiphon_config_file_content }}"
     dest: "{{ orchestra_psiphon_config_file }}"
 
+- name: Write tor targets file
+  template:
+    src: tor_targets.json
+    dest: "{{ orchestra_tor_targets_file }}"
+
 - name: orchestrate webservice
   docker_container:
     image: "{{ orchestrate_docker_image }}"

--- a/ansible/roles/probe-services/templates/ooni-orchestrate.toml
+++ b/ansible/roles/probe-services/templates/ooni-orchestrate.toml
@@ -19,3 +19,6 @@ url = "{{ orchestra_database_url }}"
 
 [psiphon]
 config-file = "{{ orchestra_psiphon_config_file }}"
+
+[tor]
+targets-file = "{{ orchestra_tor_targets_file }}"

--- a/ansible/roles/probe-services/templates/tor_targets.json
+++ b/ansible/roles/probe-services/templates/tor_targets.json
@@ -1,0 +1,21 @@
+{
+  "f372c264e9a470335d9ac79fe780847bda052aa3b6a9ee5ff497cb6501634f9f": {
+    "address": "38.229.1.78:80",
+    "fingerprint": "C8CBDB2464FC9804A69531437BCF2BE31FDD2EE4",
+    "params": {
+      "cert": [
+        "Hmyfd2ev46gGY7NoVxA9ngrPF2zCZtzskRTzoWXbxNkzeVnGFPWmrTtILRyqCTjHR+s9dg"
+      ],
+      "iat-mode": ["1"]
+    },
+    "protocol": "obfs4"
+  },
+  "66.111.2.131:9030": {
+    "address":  "66.111.2.131:9030",
+    "protocol": "dir_port"
+  },
+  "66.111.2.131:9001": {
+    "address":  "66.111.2.131:9001",
+    "protocol": "or_port"
+  }
+}


### PR DESCRIPTION
This enough to enable me to release a probe-engine with the tor experiment. There is a bunch of follow-up questions to consider, e.g., how to update this information more or less automatically? But I think they are secondary to the objective of starting to have the tor experiment merged to master.

Closes ooni/backend#289.
