### PR TITLE
Deploy explorer-test with ams-pg-test as API server

### DIFF
--- a/ansible/deploy-explorer.yml
+++ b/ansible/deploy-explorer.yml
@@ -25,7 +25,7 @@
         - 'mia-explorer-test.ooni.nu'
         - 'explorer-test.ooni.io'
     - role: explorer
-      explorer_next_tag: '20201027-64a902c9'
+      explorer_next_tag: '20201102-5e6edc2d'
       explorer_public_hostname: 'explorer-test.ooni.io'
       explorer_domain: 'mia-explorer-test.ooni.nu'
       tags: explorer-test

--- a/ansible/roles/explorer/tasks/main.yml
+++ b/ansible/roles/explorer/tasks/main.yml
@@ -26,9 +26,9 @@
     name: explrr
     driver_options:
       com.docker.network.bridge.name: brexplrr
-    ipam_options:
-      subnet: 172.27.33.0/24
-      gateway: 172.27.33.1
+    ipam_config:
+      - subnet: 172.27.33.0/24
+        gateway: 172.27.33.1
 
 - name: OONI Explorer webservice
   docker_container:


### PR DESCRIPTION
Aside from updating the docker container tag, I also made a small change to address a deprecation warning. The idea to get a bit more confident about handling ansible configurations. 