### PR TITLE
Tor targets

### DIFF
--- a/ansible/roles/ooni-backend/templates/tor_targets.json
+++ b/ansible/roles/ooni-backend/templates/tor_targets.json
@@ -1,123 +1,100 @@
 {
   "128.31.0.39:9101": {
     "address": "128.31.0.39:9101",
-    "name": "moria1",
     "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
+    "name": "moria1",
     "protocol": "or_port_dirauth"
   },
   "128.31.0.39:9131": {
     "address": "128.31.0.39:9131",
-    "name": "moria1",
     "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
-    "protocol": "dir_port"
-  },
-  "86.59.21.38:443": {
-    "address": "86.59.21.38:443",
-    "name": "tor26",
-    "fingerprint": "847B1F850344D7876491A54892F904934E4EB85D",
-    "protocol": "or_port_dirauth"
-  },
-  "86.59.21.38:80": {
-    "address": "86.59.21.38:80",
-    "name": "tor26",
-    "fingerprint": "847B1F850344D7876491A54892F904934E4EB85D",
-    "protocol": "dir_port"
-  },
-  "45.66.33.45:443": {
-    "address": "45.66.33.45:443",
-    "name": "dizum",
-    "fingerprint": "7EA6EAD6FD83083C538F44038BBFA077587DD755",
-    "protocol": "or_port_dirauth"
-  },
-  "45.66.33.45:80": {
-    "address": "45.66.33.45:80",
-    "name": "dizum",
-    "fingerprint": "7EA6EAD6FD83083C538F44038BBFA077587DD755",
-    "protocol": "dir_port"
-  },
-  "66.111.2.131:9001": {
-    "address": "66.111.2.131:9001",
-    "name": "Serge",
-    "fingerprint": "BA44A889E64B93FAA2B114E02C2A279A8555C533",
-    "protocol": "or_port_dirauth"
-  },
-  "66.111.2.131:9030": {
-    "address": "66.111.2.131:9030",
-    "name": "Serge",
-    "fingerprint": "BA44A889E64B93FAA2B114E02C2A279A8555C533",
+    "name": "moria1",
     "protocol": "dir_port"
   },
   "131.188.40.189:443": {
     "address": "131.188.40.189:443",
-    "name": "gabelmoo",
     "fingerprint": "F2044413DAC2E02E3D6BCF4735A19BCA1DE97281",
+    "name": "gabelmoo",
     "protocol": "or_port_dirauth"
   },
   "131.188.40.189:80": {
     "address": "131.188.40.189:80",
-    "name": "gabelmoo",
     "fingerprint": "F2044413DAC2E02E3D6BCF4735A19BCA1DE97281",
-    "protocol": "dir_port"
-  },
-  "193.23.244.244:443": {
-    "address": "193.23.244.244:443",
-    "name": "dannenberg",
-    "fingerprint": "7BE683E65D48141321C5ED92F075C55364AC7123",
-    "protocol": "or_port_dirauth"
-  },
-  "193.23.244.244:80": {
-    "address": "193.23.244.244:80",
-    "name": "dannenberg",
-    "fingerprint": "7BE683E65D48141321C5ED92F075C55364AC7123",
-    "protocol": "dir_port"
-  },
-  "171.25.193.9:80": {
-    "address": "171.25.193.9:80",
-    "name": "maatuska",
-    "fingerprint": "BD6A829255CB08E66FBE7D3748363586E46B3810",
-    "protocol": "or_port_dirauth"
-  },
-  "171.25.193.9:443": {
-    "address": "171.25.193.9:443",
-    "name": "maatuska",
-    "fingerprint": "BD6A829255CB08E66FBE7D3748363586E46B3810",
+    "name": "gabelmoo",
     "protocol": "dir_port"
   },
   "154.35.175.225:443": {
     "address": "154.35.175.225:443",
-    "name": "Faravahar",
     "fingerprint": "CF6D0AAFB385BE71B8E111FC5CFF4B47923733BC",
+    "name": "Faravahar",
     "protocol": "or_port_dirauth"
   },
   "154.35.175.225:80": {
     "address": "154.35.175.225:80",
-    "name": "Faravahar",
     "fingerprint": "CF6D0AAFB385BE71B8E111FC5CFF4B47923733BC",
+    "name": "Faravahar",
+    "protocol": "dir_port"
+  },
+  "171.25.193.9:443": {
+    "address": "171.25.193.9:443",
+    "fingerprint": "BD6A829255CB08E66FBE7D3748363586E46B3810",
+    "name": "maatuska",
+    "protocol": "dir_port"
+  },
+  "171.25.193.9:80": {
+    "address": "171.25.193.9:80",
+    "fingerprint": "BD6A829255CB08E66FBE7D3748363586E46B3810",
+    "name": "maatuska",
+    "protocol": "or_port_dirauth"
+  },
+  "193.23.244.244:443": {
+    "address": "193.23.244.244:443",
+    "fingerprint": "7BE683E65D48141321C5ED92F075C55364AC7123",
+    "name": "dannenberg",
+    "protocol": "or_port_dirauth"
+  },
+  "193.23.244.244:80": {
+    "address": "193.23.244.244:80",
+    "fingerprint": "7BE683E65D48141321C5ED92F075C55364AC7123",
+    "name": "dannenberg",
     "protocol": "dir_port"
   },
   "199.58.81.140:443": {
     "address": "199.58.81.140:443",
-    "name": "longclaw",
     "fingerprint": "74A910646BCEEFBCD2E874FC1DC997430F968145",
+    "name": "longclaw",
     "protocol": "or_port_dirauth"
   },
   "199.58.81.140:80": {
     "address": "199.58.81.140:80",
-    "name": "longclaw",
     "fingerprint": "74A910646BCEEFBCD2E874FC1DC997430F968145",
+    "name": "longclaw",
     "protocol": "dir_port"
   },
   "204.13.164.118:443": {
     "address": "204.13.164.118:443",
-    "name": "bastet",
     "fingerprint": "24E2F139121D4394C54B5BCC368B3B411857C413",
+    "name": "bastet",
     "protocol": "or_port_dirauth"
   },
   "204.13.164.118:80": {
     "address": "204.13.164.118:80",
-    "name": "bastet",
     "fingerprint": "24E2F139121D4394C54B5BCC368B3B411857C413",
+    "name": "bastet",
     "protocol": "dir_port"
+  },
+  "2d7292b5163fb7de5b24cd04032c93a2d4c454431de3a00b5a6d4a3309529e49": {
+    "address": "193.11.166.194:27020",
+    "fingerprint": "86AC7B8D430DAC4117E9F42C9EAED18133863AAF",
+    "params": {
+      "cert": [
+        "0LDeJH4JzMDtkJJrFphJCiPqKx7loozKN7VNfuukMGfHO0Z8OGdzHVkhVAOfo1mUdv9cMg"
+      ],
+      "iat-mode": [
+        "0"
+      ]
+    },
+    "protocol": "obfs4"
   },
   "3fa772a44e07856b4c70e958b2f6dc8a29450a823509d5dbbf8b884e7fb5bb9d": {
     "address": "192.95.36.142:443",
@@ -131,6 +108,120 @@
       ]
     },
     "protocol": "obfs4"
+  },
+  "45.66.33.45:443": {
+    "address": "45.66.33.45:443",
+    "fingerprint": "7EA6EAD6FD83083C538F44038BBFA077587DD755",
+    "name": "dizum",
+    "protocol": "or_port_dirauth"
+  },
+  "45.66.33.45:80": {
+    "address": "45.66.33.45:80",
+    "fingerprint": "7EA6EAD6FD83083C538F44038BBFA077587DD755",
+    "name": "dizum",
+    "protocol": "dir_port"
+  },
+  "49116bf72d336bb8724fd3a06a5afa7bbd4e7baef35fbcdb9a98d13e702270ad": {
+    "address": "146.57.248.225:22",
+    "fingerprint": "10A6CD36A537FCE513A322361547444B393989F0",
+    "params": {
+      "cert": [
+        "K1gDtDAIcUfeLqbstggjIw2rtgIKqdIhUlHp82XRqNSq/mtAjp1BIC9vHKJ2FAEpGssTPw"
+      ],
+      "iat-mode": [
+        "0"
+      ]
+    },
+    "protocol": "obfs4"
+  },
+  "4a330634c5d678887f0f7c299490af43a6ac9fa944a6cc2140ab264c9ec124a0": {
+    "address": "209.148.46.65:443",
+    "fingerprint": "74FAD13168806246602538555B5521A0383A1875",
+    "params": {
+      "cert": [
+        "ssH+9rP8dG2NLDN2XuFw63hIO/9MNNinLmxQDpVa+7kTOa9/m+tGWT1SmSYpQ9uTBGa6Hw"
+      ],
+      "iat-mode": [
+        "0"
+      ]
+    },
+    "protocol": "obfs4"
+  },
+  "548eebff71da6128321c3bc1c3ec12b5bfff277ef5cde32709a33e207b57f3e2": {
+    "address": "37.218.245.14:38224",
+    "fingerprint": "D9A82D2F9C2F65A18407B1D2B764F130847F8B5D",
+    "params": {
+      "cert": [
+        "bjRaMrr1BRiAW8IE9U5z27fQaYgOhX1UCmOpg2pFpoMvo6ZgQMzLsaTzzQNTlm7hNcb+Sg"
+      ],
+      "iat-mode": [
+        "0"
+      ]
+    },
+    "protocol": "obfs4"
+  },
+  "5aeb9e43b43fc8a809b8d25aae968395a5ceea0e677caaf56e1c0a2ba002f5b5": {
+    "address": "193.11.166.194:27015",
+    "fingerprint": "2D82C2E354D531A68469ADF7F878FA6060C6BACA",
+    "params": {
+      "cert": [
+        "4TLQPJrTSaDffMK7Nbao6LC7G9OW/NHkUwIdjLSS3KYf0Nv4/nQiiI8dY2TcsQx01NniOg"
+      ],
+      "iat-mode": [
+        "0"
+      ]
+    },
+    "protocol": "obfs4"
+  },
+  "66.111.2.131:9001": {
+    "address": "66.111.2.131:9001",
+    "fingerprint": "BA44A889E64B93FAA2B114E02C2A279A8555C533",
+    "name": "Serge",
+    "protocol": "or_port_dirauth"
+  },
+  "66.111.2.131:9030": {
+    "address": "66.111.2.131:9030",
+    "fingerprint": "BA44A889E64B93FAA2B114E02C2A279A8555C533",
+    "name": "Serge",
+    "protocol": "dir_port"
+  },
+  "662218447d396b9d4f01b585457d267735601fedbeb9a19b86b942f238fe4e7b": {
+    "address": "51.222.13.177:80",
+    "fingerprint": "5EDAC3B810E12B01F6FD8050D2FD3E277B289A08",
+    "params": {
+      "cert": [
+        "2uplIpLQ0q9+0qMFrK5pkaYRDOe460LL9WHBvatgkuRr/SL31wBOEupaMMJ6koRE6Ld0ew"
+      ],
+      "iat-mode": [
+        "0"
+      ]
+    },
+    "protocol": "obfs4"
+  },
+  "75fe96d641a078fee06529af376d7f8c92757596e48558d5d02baa1e10321d10": {
+    "address": "45.145.95.6:27015",
+    "fingerprint": "C5B7CD6946FF10C5B3E89691A7D3F2C122D2117C",
+    "params": {
+      "cert": [
+        "TD7PbUO0/0k6xYHMPW3vJxICfkMZNdkRrb63Zhl5j9dW3iRGiCx0A7mPhe5T2EDzQ35+Zw"
+      ],
+      "iat-mode": [
+        "0"
+      ]
+    },
+    "protocol": "obfs4"
+  },
+  "86.59.21.38:443": {
+    "address": "86.59.21.38:443",
+    "fingerprint": "847B1F850344D7876491A54892F904934E4EB85D",
+    "name": "tor26",
+    "protocol": "or_port_dirauth"
+  },
+  "86.59.21.38:80": {
+    "address": "86.59.21.38:80",
+    "fingerprint": "847B1F850344D7876491A54892F904934E4EB85D",
+    "name": "tor26",
+    "protocol": "dir_port"
   },
   "99e9adc8bba0d60982dbc655b5e8735d88ad788905c3713a39eff3224b617eeb": {
     "address": "38.229.1.78:80",
@@ -158,25 +249,12 @@
     },
     "protocol": "obfs4"
   },
-  "548eebff71da6128321c3bc1c3ec12b5bfff277ef5cde32709a33e207b57f3e2": {
-    "address": "37.218.245.14:38224",
-    "fingerprint": "D9A82D2F9C2F65A18407B1D2B764F130847F8B5D",
+  "b7c0e3f183ad85a6686ec68344765cec57906b215e7b82a98a9ca013cb980efa": {
+    "address": "193.11.166.194:27025",
+    "fingerprint": "1AE2C08904527FEA90C4C4F8C1083EA59FBC6FAF",
     "params": {
       "cert": [
-        "bjRaMrr1BRiAW8IE9U5z27fQaYgOhX1UCmOpg2pFpoMvo6ZgQMzLsaTzzQNTlm7hNcb+Sg"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "d2d6e34abeda851f7cd37138ffafcce992b2ccdb0f263eb90ab75d7adbd5eeba": {
-    "address": "85.31.186.98:443",
-    "fingerprint": "011F2599C0E9B27EE74B353155E244813763C3E5",
-    "params": {
-      "cert": [
-        "ayq0XzCwhpdysn5o0EyDUbmSOx3X/oTEbzDMvczHOdBJKlvIdHHLJGkZARtT4dcBFArPPg"
+        "ItvYZzW5tn6v3G4UnQa6Qz04Npro6e81AP70YujmK/KXwDFPTs3aHXcHp4n8Vt6w/bv8cA"
       ],
       "iat-mode": [
         "0"
@@ -197,90 +275,12 @@
     },
     "protocol": "obfs4"
   },
-  "bc7bc5fb57052ee5252e807443b9ab67307dbdb5ce79187c4360182a300dd0f8": {
-    "address": "144.217.20.138:80",
-    "fingerprint": "FB70B257C162BF1038CA669D568D76F5B7F0BABB",
+  "d2d6e34abeda851f7cd37138ffafcce992b2ccdb0f263eb90ab75d7adbd5eeba": {
+    "address": "85.31.186.98:443",
+    "fingerprint": "011F2599C0E9B27EE74B353155E244813763C3E5",
     "params": {
       "cert": [
-        "vYIV5MgrghGQvZPIi1tJwnzorMgqgmlKaB77Y3Z9Q/v94wZBOAXkW+fdx4aSxLVnKO+xNw"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "5aeb9e43b43fc8a809b8d25aae968395a5ceea0e677caaf56e1c0a2ba002f5b5": {
-    "address": "193.11.166.194:27015",
-    "fingerprint": "2D82C2E354D531A68469ADF7F878FA6060C6BACA",
-    "params": {
-      "cert": [
-        "4TLQPJrTSaDffMK7Nbao6LC7G9OW/NHkUwIdjLSS3KYf0Nv4/nQiiI8dY2TcsQx01NniOg"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "2d7292b5163fb7de5b24cd04032c93a2d4c454431de3a00b5a6d4a3309529e49": {
-    "address": "193.11.166.194:27020",
-    "fingerprint": "86AC7B8D430DAC4117E9F42C9EAED18133863AAF",
-    "params": {
-      "cert": [
-        "0LDeJH4JzMDtkJJrFphJCiPqKx7loozKN7VNfuukMGfHO0Z8OGdzHVkhVAOfo1mUdv9cMg"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "b7c0e3f183ad85a6686ec68344765cec57906b215e7b82a98a9ca013cb980efa": {
-    "address": "193.11.166.194:27025",
-    "fingerprint": "1AE2C08904527FEA90C4C4F8C1083EA59FBC6FAF",
-    "params": {
-      "cert": [
-        "ItvYZzW5tn6v3G4UnQa6Qz04Npro6e81AP70YujmK/KXwDFPTs3aHXcHp4n8Vt6w/bv8cA"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "4a330634c5d678887f0f7c299490af43a6ac9fa944a6cc2140ab264c9ec124a0": {
-    "address": "209.148.46.65:443",
-    "fingerprint": "74FAD13168806246602538555B5521A0383A1875",
-    "params": {
-      "cert": [
-        "ssH+9rP8dG2NLDN2XuFw63hIO/9MNNinLmxQDpVa+7kTOa9/m+tGWT1SmSYpQ9uTBGa6Hw"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "49116bf72d336bb8724fd3a06a5afa7bbd4e7baef35fbcdb9a98d13e702270ad": {
-    "address": "146.57.248.225:22",
-    "fingerprint": "10A6CD36A537FCE513A322361547444B393989F0",
-    "params": {
-      "cert": [
-        "K1gDtDAIcUfeLqbstggjIw2rtgIKqdIhUlHp82XRqNSq/mtAjp1BIC9vHKJ2FAEpGssTPw"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "75fe96d641a078fee06529af376d7f8c92757596e48558d5d02baa1e10321d10": {
-    "address": "45.145.95.6:27015",
-    "fingerprint": "C5B7CD6946FF10C5B3E89691A7D3F2C122D2117C",
-    "params": {
-      "cert": [
-        "TD7PbUO0/0k6xYHMPW3vJxICfkMZNdkRrb63Zhl5j9dW3iRGiCx0A7mPhe5T2EDzQ35+Zw"
+        "ayq0XzCwhpdysn5o0EyDUbmSOx3X/oTEbzDMvczHOdBJKlvIdHHLJGkZARtT4dcBFArPPg"
       ],
       "iat-mode": [
         "0"
@@ -294,19 +294,6 @@
     "params": {
       "cert": [
         "TD7PbUO0/0k6xYHMPW3vJxICfkMZNdkRrb63Zhl5j9dW3iRGiCx0A7mPhe5T2EDzQ35+Zw"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "fa69b2ee7a7c8975af2452ecd566f67a6459d397a4cefc30be86a670675cdc23": {
-    "address": "51.222.13.177:80",
-    "fingerprint": "5EDAC3B810E12B01F6FD8050D2FD3E277B289A08",
-    "params": {
-      "cert": [
-        "2uplIpLQ0q9+0qMFrK5pkaYRDOe460LL9WHBvatgkuRr/SL31wBOEupaMMJ6koRE6Ld0ew"
       ],
       "iat-mode": [
         "0"

--- a/ansible/roles/probe-services/templates/tor_targets.json
+++ b/ansible/roles/probe-services/templates/tor_targets.json
@@ -1,123 +1,100 @@
 {
   "128.31.0.39:9101": {
     "address": "128.31.0.39:9101",
-    "name": "moria1",
     "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
+    "name": "moria1",
     "protocol": "or_port_dirauth"
   },
   "128.31.0.39:9131": {
     "address": "128.31.0.39:9131",
-    "name": "moria1",
     "fingerprint": "9695DFC35FFEB861329B9F1AB04C46397020CE31",
-    "protocol": "dir_port"
-  },
-  "86.59.21.38:443": {
-    "address": "86.59.21.38:443",
-    "name": "tor26",
-    "fingerprint": "847B1F850344D7876491A54892F904934E4EB85D",
-    "protocol": "or_port_dirauth"
-  },
-  "86.59.21.38:80": {
-    "address": "86.59.21.38:80",
-    "name": "tor26",
-    "fingerprint": "847B1F850344D7876491A54892F904934E4EB85D",
-    "protocol": "dir_port"
-  },
-  "45.66.33.45:443": {
-    "address": "45.66.33.45:443",
-    "name": "dizum",
-    "fingerprint": "7EA6EAD6FD83083C538F44038BBFA077587DD755",
-    "protocol": "or_port_dirauth"
-  },
-  "45.66.33.45:80": {
-    "address": "45.66.33.45:80",
-    "name": "dizum",
-    "fingerprint": "7EA6EAD6FD83083C538F44038BBFA077587DD755",
-    "protocol": "dir_port"
-  },
-  "66.111.2.131:9001": {
-    "address": "66.111.2.131:9001",
-    "name": "Serge",
-    "fingerprint": "BA44A889E64B93FAA2B114E02C2A279A8555C533",
-    "protocol": "or_port_dirauth"
-  },
-  "66.111.2.131:9030": {
-    "address": "66.111.2.131:9030",
-    "name": "Serge",
-    "fingerprint": "BA44A889E64B93FAA2B114E02C2A279A8555C533",
+    "name": "moria1",
     "protocol": "dir_port"
   },
   "131.188.40.189:443": {
     "address": "131.188.40.189:443",
-    "name": "gabelmoo",
     "fingerprint": "F2044413DAC2E02E3D6BCF4735A19BCA1DE97281",
+    "name": "gabelmoo",
     "protocol": "or_port_dirauth"
   },
   "131.188.40.189:80": {
     "address": "131.188.40.189:80",
-    "name": "gabelmoo",
     "fingerprint": "F2044413DAC2E02E3D6BCF4735A19BCA1DE97281",
-    "protocol": "dir_port"
-  },
-  "193.23.244.244:443": {
-    "address": "193.23.244.244:443",
-    "name": "dannenberg",
-    "fingerprint": "7BE683E65D48141321C5ED92F075C55364AC7123",
-    "protocol": "or_port_dirauth"
-  },
-  "193.23.244.244:80": {
-    "address": "193.23.244.244:80",
-    "name": "dannenberg",
-    "fingerprint": "7BE683E65D48141321C5ED92F075C55364AC7123",
-    "protocol": "dir_port"
-  },
-  "171.25.193.9:80": {
-    "address": "171.25.193.9:80",
-    "name": "maatuska",
-    "fingerprint": "BD6A829255CB08E66FBE7D3748363586E46B3810",
-    "protocol": "or_port_dirauth"
-  },
-  "171.25.193.9:443": {
-    "address": "171.25.193.9:443",
-    "name": "maatuska",
-    "fingerprint": "BD6A829255CB08E66FBE7D3748363586E46B3810",
+    "name": "gabelmoo",
     "protocol": "dir_port"
   },
   "154.35.175.225:443": {
     "address": "154.35.175.225:443",
-    "name": "Faravahar",
     "fingerprint": "CF6D0AAFB385BE71B8E111FC5CFF4B47923733BC",
+    "name": "Faravahar",
     "protocol": "or_port_dirauth"
   },
   "154.35.175.225:80": {
     "address": "154.35.175.225:80",
-    "name": "Faravahar",
     "fingerprint": "CF6D0AAFB385BE71B8E111FC5CFF4B47923733BC",
+    "name": "Faravahar",
+    "protocol": "dir_port"
+  },
+  "171.25.193.9:443": {
+    "address": "171.25.193.9:443",
+    "fingerprint": "BD6A829255CB08E66FBE7D3748363586E46B3810",
+    "name": "maatuska",
+    "protocol": "dir_port"
+  },
+  "171.25.193.9:80": {
+    "address": "171.25.193.9:80",
+    "fingerprint": "BD6A829255CB08E66FBE7D3748363586E46B3810",
+    "name": "maatuska",
+    "protocol": "or_port_dirauth"
+  },
+  "193.23.244.244:443": {
+    "address": "193.23.244.244:443",
+    "fingerprint": "7BE683E65D48141321C5ED92F075C55364AC7123",
+    "name": "dannenberg",
+    "protocol": "or_port_dirauth"
+  },
+  "193.23.244.244:80": {
+    "address": "193.23.244.244:80",
+    "fingerprint": "7BE683E65D48141321C5ED92F075C55364AC7123",
+    "name": "dannenberg",
     "protocol": "dir_port"
   },
   "199.58.81.140:443": {
     "address": "199.58.81.140:443",
-    "name": "longclaw",
     "fingerprint": "74A910646BCEEFBCD2E874FC1DC997430F968145",
+    "name": "longclaw",
     "protocol": "or_port_dirauth"
   },
   "199.58.81.140:80": {
     "address": "199.58.81.140:80",
-    "name": "longclaw",
     "fingerprint": "74A910646BCEEFBCD2E874FC1DC997430F968145",
+    "name": "longclaw",
     "protocol": "dir_port"
   },
   "204.13.164.118:443": {
     "address": "204.13.164.118:443",
-    "name": "bastet",
     "fingerprint": "24E2F139121D4394C54B5BCC368B3B411857C413",
+    "name": "bastet",
     "protocol": "or_port_dirauth"
   },
   "204.13.164.118:80": {
     "address": "204.13.164.118:80",
-    "name": "bastet",
     "fingerprint": "24E2F139121D4394C54B5BCC368B3B411857C413",
+    "name": "bastet",
     "protocol": "dir_port"
+  },
+  "2d7292b5163fb7de5b24cd04032c93a2d4c454431de3a00b5a6d4a3309529e49": {
+    "address": "193.11.166.194:27020",
+    "fingerprint": "86AC7B8D430DAC4117E9F42C9EAED18133863AAF",
+    "params": {
+      "cert": [
+        "0LDeJH4JzMDtkJJrFphJCiPqKx7loozKN7VNfuukMGfHO0Z8OGdzHVkhVAOfo1mUdv9cMg"
+      ],
+      "iat-mode": [
+        "0"
+      ]
+    },
+    "protocol": "obfs4"
   },
   "3fa772a44e07856b4c70e958b2f6dc8a29450a823509d5dbbf8b884e7fb5bb9d": {
     "address": "192.95.36.142:443",
@@ -131,6 +108,120 @@
       ]
     },
     "protocol": "obfs4"
+  },
+  "45.66.33.45:443": {
+    "address": "45.66.33.45:443",
+    "fingerprint": "7EA6EAD6FD83083C538F44038BBFA077587DD755",
+    "name": "dizum",
+    "protocol": "or_port_dirauth"
+  },
+  "45.66.33.45:80": {
+    "address": "45.66.33.45:80",
+    "fingerprint": "7EA6EAD6FD83083C538F44038BBFA077587DD755",
+    "name": "dizum",
+    "protocol": "dir_port"
+  },
+  "49116bf72d336bb8724fd3a06a5afa7bbd4e7baef35fbcdb9a98d13e702270ad": {
+    "address": "146.57.248.225:22",
+    "fingerprint": "10A6CD36A537FCE513A322361547444B393989F0",
+    "params": {
+      "cert": [
+        "K1gDtDAIcUfeLqbstggjIw2rtgIKqdIhUlHp82XRqNSq/mtAjp1BIC9vHKJ2FAEpGssTPw"
+      ],
+      "iat-mode": [
+        "0"
+      ]
+    },
+    "protocol": "obfs4"
+  },
+  "4a330634c5d678887f0f7c299490af43a6ac9fa944a6cc2140ab264c9ec124a0": {
+    "address": "209.148.46.65:443",
+    "fingerprint": "74FAD13168806246602538555B5521A0383A1875",
+    "params": {
+      "cert": [
+        "ssH+9rP8dG2NLDN2XuFw63hIO/9MNNinLmxQDpVa+7kTOa9/m+tGWT1SmSYpQ9uTBGa6Hw"
+      ],
+      "iat-mode": [
+        "0"
+      ]
+    },
+    "protocol": "obfs4"
+  },
+  "548eebff71da6128321c3bc1c3ec12b5bfff277ef5cde32709a33e207b57f3e2": {
+    "address": "37.218.245.14:38224",
+    "fingerprint": "D9A82D2F9C2F65A18407B1D2B764F130847F8B5D",
+    "params": {
+      "cert": [
+        "bjRaMrr1BRiAW8IE9U5z27fQaYgOhX1UCmOpg2pFpoMvo6ZgQMzLsaTzzQNTlm7hNcb+Sg"
+      ],
+      "iat-mode": [
+        "0"
+      ]
+    },
+    "protocol": "obfs4"
+  },
+  "5aeb9e43b43fc8a809b8d25aae968395a5ceea0e677caaf56e1c0a2ba002f5b5": {
+    "address": "193.11.166.194:27015",
+    "fingerprint": "2D82C2E354D531A68469ADF7F878FA6060C6BACA",
+    "params": {
+      "cert": [
+        "4TLQPJrTSaDffMK7Nbao6LC7G9OW/NHkUwIdjLSS3KYf0Nv4/nQiiI8dY2TcsQx01NniOg"
+      ],
+      "iat-mode": [
+        "0"
+      ]
+    },
+    "protocol": "obfs4"
+  },
+  "66.111.2.131:9001": {
+    "address": "66.111.2.131:9001",
+    "fingerprint": "BA44A889E64B93FAA2B114E02C2A279A8555C533",
+    "name": "Serge",
+    "protocol": "or_port_dirauth"
+  },
+  "66.111.2.131:9030": {
+    "address": "66.111.2.131:9030",
+    "fingerprint": "BA44A889E64B93FAA2B114E02C2A279A8555C533",
+    "name": "Serge",
+    "protocol": "dir_port"
+  },
+  "662218447d396b9d4f01b585457d267735601fedbeb9a19b86b942f238fe4e7b": {
+    "address": "51.222.13.177:80",
+    "fingerprint": "5EDAC3B810E12B01F6FD8050D2FD3E277B289A08",
+    "params": {
+      "cert": [
+        "2uplIpLQ0q9+0qMFrK5pkaYRDOe460LL9WHBvatgkuRr/SL31wBOEupaMMJ6koRE6Ld0ew"
+      ],
+      "iat-mode": [
+        "0"
+      ]
+    },
+    "protocol": "obfs4"
+  },
+  "75fe96d641a078fee06529af376d7f8c92757596e48558d5d02baa1e10321d10": {
+    "address": "45.145.95.6:27015",
+    "fingerprint": "C5B7CD6946FF10C5B3E89691A7D3F2C122D2117C",
+    "params": {
+      "cert": [
+        "TD7PbUO0/0k6xYHMPW3vJxICfkMZNdkRrb63Zhl5j9dW3iRGiCx0A7mPhe5T2EDzQ35+Zw"
+      ],
+      "iat-mode": [
+        "0"
+      ]
+    },
+    "protocol": "obfs4"
+  },
+  "86.59.21.38:443": {
+    "address": "86.59.21.38:443",
+    "fingerprint": "847B1F850344D7876491A54892F904934E4EB85D",
+    "name": "tor26",
+    "protocol": "or_port_dirauth"
+  },
+  "86.59.21.38:80": {
+    "address": "86.59.21.38:80",
+    "fingerprint": "847B1F850344D7876491A54892F904934E4EB85D",
+    "name": "tor26",
+    "protocol": "dir_port"
   },
   "99e9adc8bba0d60982dbc655b5e8735d88ad788905c3713a39eff3224b617eeb": {
     "address": "38.229.1.78:80",
@@ -158,25 +249,12 @@
     },
     "protocol": "obfs4"
   },
-  "548eebff71da6128321c3bc1c3ec12b5bfff277ef5cde32709a33e207b57f3e2": {
-    "address": "37.218.245.14:38224",
-    "fingerprint": "D9A82D2F9C2F65A18407B1D2B764F130847F8B5D",
+  "b7c0e3f183ad85a6686ec68344765cec57906b215e7b82a98a9ca013cb980efa": {
+    "address": "193.11.166.194:27025",
+    "fingerprint": "1AE2C08904527FEA90C4C4F8C1083EA59FBC6FAF",
     "params": {
       "cert": [
-        "bjRaMrr1BRiAW8IE9U5z27fQaYgOhX1UCmOpg2pFpoMvo6ZgQMzLsaTzzQNTlm7hNcb+Sg"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "d2d6e34abeda851f7cd37138ffafcce992b2ccdb0f263eb90ab75d7adbd5eeba": {
-    "address": "85.31.186.98:443",
-    "fingerprint": "011F2599C0E9B27EE74B353155E244813763C3E5",
-    "params": {
-      "cert": [
-        "ayq0XzCwhpdysn5o0EyDUbmSOx3X/oTEbzDMvczHOdBJKlvIdHHLJGkZARtT4dcBFArPPg"
+        "ItvYZzW5tn6v3G4UnQa6Qz04Npro6e81AP70YujmK/KXwDFPTs3aHXcHp4n8Vt6w/bv8cA"
       ],
       "iat-mode": [
         "0"
@@ -197,90 +275,12 @@
     },
     "protocol": "obfs4"
   },
-  "bc7bc5fb57052ee5252e807443b9ab67307dbdb5ce79187c4360182a300dd0f8": {
-    "address": "144.217.20.138:80",
-    "fingerprint": "FB70B257C162BF1038CA669D568D76F5B7F0BABB",
+  "d2d6e34abeda851f7cd37138ffafcce992b2ccdb0f263eb90ab75d7adbd5eeba": {
+    "address": "85.31.186.98:443",
+    "fingerprint": "011F2599C0E9B27EE74B353155E244813763C3E5",
     "params": {
       "cert": [
-        "vYIV5MgrghGQvZPIi1tJwnzorMgqgmlKaB77Y3Z9Q/v94wZBOAXkW+fdx4aSxLVnKO+xNw"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "5aeb9e43b43fc8a809b8d25aae968395a5ceea0e677caaf56e1c0a2ba002f5b5": {
-    "address": "193.11.166.194:27015",
-    "fingerprint": "2D82C2E354D531A68469ADF7F878FA6060C6BACA",
-    "params": {
-      "cert": [
-        "4TLQPJrTSaDffMK7Nbao6LC7G9OW/NHkUwIdjLSS3KYf0Nv4/nQiiI8dY2TcsQx01NniOg"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "2d7292b5163fb7de5b24cd04032c93a2d4c454431de3a00b5a6d4a3309529e49": {
-    "address": "193.11.166.194:27020",
-    "fingerprint": "86AC7B8D430DAC4117E9F42C9EAED18133863AAF",
-    "params": {
-      "cert": [
-        "0LDeJH4JzMDtkJJrFphJCiPqKx7loozKN7VNfuukMGfHO0Z8OGdzHVkhVAOfo1mUdv9cMg"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "b7c0e3f183ad85a6686ec68344765cec57906b215e7b82a98a9ca013cb980efa": {
-    "address": "193.11.166.194:27025",
-    "fingerprint": "1AE2C08904527FEA90C4C4F8C1083EA59FBC6FAF",
-    "params": {
-      "cert": [
-        "ItvYZzW5tn6v3G4UnQa6Qz04Npro6e81AP70YujmK/KXwDFPTs3aHXcHp4n8Vt6w/bv8cA"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "4a330634c5d678887f0f7c299490af43a6ac9fa944a6cc2140ab264c9ec124a0": {
-    "address": "209.148.46.65:443",
-    "fingerprint": "74FAD13168806246602538555B5521A0383A1875",
-    "params": {
-      "cert": [
-        "ssH+9rP8dG2NLDN2XuFw63hIO/9MNNinLmxQDpVa+7kTOa9/m+tGWT1SmSYpQ9uTBGa6Hw"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "49116bf72d336bb8724fd3a06a5afa7bbd4e7baef35fbcdb9a98d13e702270ad": {
-    "address": "146.57.248.225:22",
-    "fingerprint": "10A6CD36A537FCE513A322361547444B393989F0",
-    "params": {
-      "cert": [
-        "K1gDtDAIcUfeLqbstggjIw2rtgIKqdIhUlHp82XRqNSq/mtAjp1BIC9vHKJ2FAEpGssTPw"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "75fe96d641a078fee06529af376d7f8c92757596e48558d5d02baa1e10321d10": {
-    "address": "45.145.95.6:27015",
-    "fingerprint": "C5B7CD6946FF10C5B3E89691A7D3F2C122D2117C",
-    "params": {
-      "cert": [
-        "TD7PbUO0/0k6xYHMPW3vJxICfkMZNdkRrb63Zhl5j9dW3iRGiCx0A7mPhe5T2EDzQ35+Zw"
+        "ayq0XzCwhpdysn5o0EyDUbmSOx3X/oTEbzDMvczHOdBJKlvIdHHLJGkZARtT4dcBFArPPg"
       ],
       "iat-mode": [
         "0"
@@ -294,19 +294,6 @@
     "params": {
       "cert": [
         "TD7PbUO0/0k6xYHMPW3vJxICfkMZNdkRrb63Zhl5j9dW3iRGiCx0A7mPhe5T2EDzQ35+Zw"
-      ],
-      "iat-mode": [
-        "0"
-      ]
-    },
-    "protocol": "obfs4"
-  },
-  "fa69b2ee7a7c8975af2452ecd566f67a6459d397a4cefc30be86a670675cdc23": {
-    "address": "51.222.13.177:80",
-    "fingerprint": "5EDAC3B810E12B01F6FD8050D2FD3E277B289A08",
-    "params": {
-      "cert": [
-        "2uplIpLQ0q9+0qMFrK5pkaYRDOe460LL9WHBvatgkuRr/SL31wBOEupaMMJ6koRE6Ld0ew"
       ],
       "iat-mode": [
         "0"

--- a/scripts/make_tor_targets.py
+++ b/scripts/make_tor_targets.py
@@ -1,0 +1,114 @@
+import json
+import hashlib
+
+from urllib.request import urlopen
+
+DIRAUTH_URL = "https://gitweb.torproject.org/tor.git/plain/src/app/config/auth_dirs.inc"
+BRIDGES_URL = "https://bridges.torproject.org/moat/circumvention/builtin"
+
+def parse_params(parts : list[str]) -> dict[str, str]:
+    params = {}
+    for p in parts:
+        k, v = p.split("=")
+        params[k] = [v]
+    return params
+
+def parse_bridge_line(line : str) -> tuple[str, dict]:
+    bridge = {}
+    parts = line.split(" ")
+    bridge["protocol"] = parts[0]
+    bridge["address"] = parts[1]
+    bridge["fingerprint"] = parts[2]
+    bridge["params"] = parse_params(parts[3:])
+
+    bridge_id = hashlib.sha256(
+            bridge["address"].encode("ascii") + bridge["fingerprint"].encode("utf-8")
+    ).hexdigest()
+
+    return bridge_id, bridge
+
+def get_bridges():
+    with urlopen(BRIDGES_URL) as resp:
+        j = json.loads(resp.read())
+
+    bridges = {}
+    for b in j["obfs4"]:
+        bridge_id, bd = parse_bridge_line(b)
+        assert bridge_id not in bridges
+        bridges[bridge_id] = bd
+    return bridges
+
+def parse_dirauth(line : str) -> dict:
+    da = {}
+    parts = line.split(" ")
+    da["name"] = parts[0]
+    assert parts[1].startswith("orport=")
+    da["or_port"] = parts[1].lstrip("orport=")
+    da["dir_address"] = parts[-11]
+    da["fingerprint"] = "".join(parts[-10:])
+    return da
+
+def get_dirauths():
+    with urlopen(DIRAUTH_URL) as resp:
+        config = resp.read().decode("utf-8")
+
+    dir_auths = {}
+
+    da_lines = []
+    current_line = ""
+    is_done = False
+    for line in config.split("\n"):
+        if is_done is True:
+            current_line = ""
+            is_done = False
+
+        if line.endswith(","):
+            is_done = True
+            line = line.rstrip(",")
+
+        line = line.strip().lstrip('"').rstrip('"')
+        current_line += line
+        if is_done:
+            da_lines.append(current_line)
+
+    for line in da_lines:
+        da = parse_dirauth(line)
+
+        or_address = da["dir_address"].split(":")[0] + ":" + da["or_port"]
+        assert or_address not in dir_auths
+        dir_auths[or_address] = {
+            "address": or_address,
+            "name": da["name"],
+            "fingerprint": da["fingerprint"],
+            "protocol": "or_port_dirauth"
+        }
+
+        assert da["dir_address"] not in dir_auths
+        dir_auths[da["dir_address"]] = {
+            "address": da["dir_address"],
+            "name": da["name"],
+            "fingerprint": da["fingerprint"],
+            "protocol": "dir_port"
+        }
+
+    return dir_auths
+
+def write_json(path : str, obj : dict):
+    with open(path, "w") as out_file:
+        json.dump(obj, out_file, indent=2, sort_keys=True)
+
+    print(f"written {path} file")
+
+def main():
+    bridges = get_bridges()
+    dir_auths = get_dirauths()
+
+    res = {}
+    res.update(dir_auths)
+    res.update(bridges)
+
+    write_json("ansible/roles/probe-services/templates/tor_targets.json", res)
+    write_json("ansible/roles/ooni-backend/templates/tor_targets.json", res)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/make_tor_targets.py
+++ b/scripts/make_tor_targets.py
@@ -45,7 +45,8 @@ def parse_dirauth(line : str) -> dict:
     da["name"] = parts[0]
     assert parts[1].startswith("orport=")
     da["or_port"] = parts[1].lstrip("orport=")
-    da["dir_address"] = parts[-11]
+    # TODO(hellais, bassosimone): This parsing algorithm ignores the IPv6 address.
+    da["dir_address"] = parts[-11]  # Note: the fingerprint consists of 10 elements
     da["fingerprint"] = "".join(parts[-10:])  # ditto
     return da
 

--- a/scripts/make_tor_targets.py
+++ b/scripts/make_tor_targets.py
@@ -46,7 +46,7 @@ def parse_dirauth(line : str) -> dict:
     assert parts[1].startswith("orport=")
     da["or_port"] = parts[1].lstrip("orport=")
     da["dir_address"] = parts[-11]
-    da["fingerprint"] = "".join(parts[-10:])
+    da["fingerprint"] = "".join(parts[-10:])  # ditto
     return da
 
 def get_dirauths():

--- a/scripts/make_tor_targets.py
+++ b/scripts/make_tor_targets.py
@@ -6,7 +6,7 @@ from urllib.request import urlopen
 DIRAUTH_URL = "https://gitweb.torproject.org/tor.git/plain/src/app/config/auth_dirs.inc"
 BRIDGES_URL = "https://bridges.torproject.org/moat/circumvention/builtin"
 
-def parse_params(parts : list[str]) -> dict[str, str]:
+def parse_params(parts: list[str]) -> dict[str, list[str]]:
     params = {}
     for p in parts:
         k, v = p.split("=")

--- a/scripts/make_tor_targets.py
+++ b/scripts/make_tor_targets.py
@@ -39,6 +39,7 @@ def get_bridges():
     return bridges
 
 def parse_dirauth(line : str) -> dict:
+    # Example: tor26 orport=443 v3ident=14C131DFC5C6F93646BE72FA1401C02A8DF2E8B4 ipv6=[2001:858:2:2:aabb:0:563b:1526]:443 86.59.21.38:80 847B 1F85 0344 D787 6491 A548 92F9 0493 4E4E B85D
     da = {}
     parts = line.split(" ")
     da["name"] = parts[0]

--- a/scripts/make_tor_targets.py
+++ b/scripts/make_tor_targets.py
@@ -13,7 +13,8 @@ def parse_params(parts: list[str]) -> dict[str, list[str]]:
         params[k] = [v]
     return params
 
-def parse_bridge_line(line : str) -> tuple[str, dict]:
+def parse_bridge_line(line: str) -> tuple[str, dict]:
+    # Example: "obfs4 146.57.248.225:22 10A6CD36A537FCE513A322361547444B393989F0 cert=K1gDtDAIcUfeLqbstggjIw2rtgIKqdIhUlHp82XRqNSq/mtAjp1BIC9vHKJ2FAEpGssTPw iat-mode=0"
     bridge = {}
     parts = line.split(" ")
     bridge["protocol"] = parts[0]


### PR DESCRIPTION
Upon manual inspection I noticed that 2 things change (it's hard to see
in the diff because we weren't previously sorting keys):

1. The removal of the smallerRichard bridge as requested by @meskio in https://github.com/ooni/sysadmin/pull/493
2. The id of the bridge 51.222.13.177:80 changed from
fa69b2ee7a7c8975af2452ecd566f67a6459d397a4cefc30be86a670675cdc23 to
662218447d396b9d4f01b585457d267735601fedbeb9a19b86b942f238fe4e7b. The
new ID is correct and it's unclear how this ID was determined in the
original PR: https://github.com/ooni/sysadmin/pull/463.

The second point might create data analysis issues in the future, but I
don't really see a way around it except remembering about this
inconsistency so we can manually remap the in the future.