### PR TITLE
fix(ooni-backend/haproxy): use path_beg to route ACME requests

### DIFF
--- a/ansible/roles/ooni-backend/templates/haproxy.cfg
+++ b/ansible/roles/ooni-backend/templates/haproxy.cfg
@@ -83,7 +83,7 @@ frontend public_80
   http-request set-var(txn.src_ipaddr_masked) src,ipmask(24,64)
 
   # ACME
-  use_backend nginx if { path /.well-known/acme-challenge }
+  use_backend nginx if { path_beg /.well-known/acme-challenge }
 
   # deb.ooni.org
   acl ACL_deb_ooni_org hdr(host) -i deb.ooni.org


### PR DESCRIPTION
This diff fixes haproxy.cfg for the ooni-backend role such that we use the path_beg filter rather than using path for routing ACME requests.

The issue with using path rather than path_beg is that path seems to be an exact filter while path_beg matches the prefix.

See https://www.haproxy.com/blog/path-based-routing-with-haproxy for an introduction about using path and path_beg.