### PR TITLE
refactor: disable orchestrate and point to new ooniprobe ecs service

### DIFF
--- a/ansible/roles/ooni-backend/templates/nginx-api-fsn.conf
+++ b/ansible/roles/ooni-backend/templates/nginx-api-fsn.conf
@@ -82,7 +82,7 @@ server {
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_read_timeout 900;
 
-      proxy_pass https://registry.ooni.io:443;
+      proxy_pass https://ooniprobe.prod.ooni.io:443;
   }
 
   # Selectively route test-list/urls to the API
@@ -111,20 +111,20 @@ server {
   # Orchestrate
   # Should match:
   # - /api/v1/test-list
-  location ~^/api/v1/(test-list|urls) {
-      proxy_http_version 1.1;
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_read_timeout 900;
+  # location ~^/api/v1/(test-list|urls) {
+  #     proxy_http_version 1.1;
+  #     proxy_set_header Host $http_host;
+  #     proxy_set_header X-Real-IP $remote_addr;
+  #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  #     proxy_set_header X-Forwarded-Proto $scheme;
+  #     proxy_read_timeout 900;
 
-      proxy_pass https://orchestrate.ooni.io:443;
-      add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-      add_header X-Frame-Options DENY always;
-      add_header X-Content-Type-Options nosniff always;
+  #     proxy_pass https://orchestrate.ooni.io:443;
+  #     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+  #     add_header X-Frame-Options DENY always;
+  #     add_header X-Content-Type-Options nosniff always;
 
-  }
+  # }
 
   # Web Connectivity Test Helper
   # Should match:


### PR DESCRIPTION
This diff points the backend-fsn host to the new ooniprobe service and also gets rid of the orchestra proxy which can now be served directly from backend-fsn